### PR TITLE
feat: fix Chinese input method Enter Key

### DIFF
--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -89,7 +89,7 @@ export default () => {
             autofocus
             disabled={loading()}
             onKeyDown={(e) => {
-              e.key === 'Enter' && handleButtonClick()
+              e.key === 'Enter' && !e.isComposing && handleButtonClick()
             }}
             w-full
             px-4


### PR DESCRIPTION
Pressing Enter does not send the message when using a Chinese input method.