### PR TITLE
set input focus after render

### DIFF
--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -65,6 +65,7 @@ export default () => {
     ])
     setCurrentAssistantMessage('')
     setLoading(false)
+    inputRef.focus()
   }
 
   const clear = () => {


### PR DESCRIPTION
渲染了 API 返回的内容后，使 input 框光标自动聚焦，如果不这样，每次都重新点一下才能继续对话。