### PR TITLE
add optional site token to protect OpenAI API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,23 @@ A demo repo based on [OpenAI GPT-3.5 Turbo API](https://platform.openai.com/docs
     ```
     OPENAI_API_KEY=sk-xxx...
     ```
-4. Run the app
+4. (Optional) Set the `SITE_TOKEN` in `.env` to protect your OpenAI API key from unauthorized access
+    ```
+    # token can be any string prarsed by regex /^@token=(.*)$/
+    # except clear
+    SITE_TOKEN=YOUR_SITE_TOKEN
+    ```
+    By adding this, vistors need to input @token=YOUR_SITE_TOKEN to access the API.
+    
+    One can also input `@token=clear` to clear the token    
+5. Run the app
     ```shell
     npm run dev
     ```
     
 ## Deploy With Vercel
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fddiu8081%2Fchatgpt-demo&env=OPENAI_API_KEY&envDescription=OpenAI%20API%20Key&envLink=https%3A%2F%2Fplatform.openai.com%2Faccount%2Fapi-keys)
-
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fandyzhshg%2Fchatgpt-demo&env=OPENAI_API_KEY&envDescription=OpenAI%20API%20Key&envLink=https%3A%2F%2Fplatform.openai.com%2Faccount%2Fapi-keys&env=SITE_TOKEN)
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "astro": "^2.0.15",
     "eventsource-parser": "^0.1.0",
     "highlight.js": "^11.7.0",
+    "js-cookie": "^3.0.1",
     "katex": "^0.6.0",
     "markdown-it": "^13.0.1",
     "markdown-it-highlightjs": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   astro: ^2.0.15
   eventsource-parser: ^0.1.0
   highlight.js: ^11.7.0
+  js-cookie: ^3.0.1
   katex: ^0.6.0
   markdown-it: ^13.0.1
   markdown-it-highlightjs: ^4.0.1
@@ -28,6 +29,7 @@ dependencies:
   astro: 2.0.15
   eventsource-parser: 0.1.0
   highlight.js: 11.7.0
+  js-cookie: 3.0.1
   katex: 0.6.0
   markdown-it: 13.0.1
   markdown-it-highlightjs: 4.0.1
@@ -2170,6 +2172,11 @@ packages:
     resolution: {integrity: sha512-NZIITw8uZQFuzQimqjUxIrIcEdxYDFIe/0xYfIlVXTkiBjjyBEvgasj5bb0/cHtPRD/NziPbT312sFrkI5ALpw==}
     hasBin: true
     dev: true
+
+  /js-cookie/3.0.1:
+    resolution: {integrity: sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==}
+    engines: {node: '>=12'}
+    dev: false
 
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}

--- a/src/pages/api/generate.ts
+++ b/src/pages/api/generate.ts
@@ -6,8 +6,15 @@ import { fetch, ProxyAgent } from 'undici'
 
 const apiKey = import.meta.env.OPENAI_API_KEY
 const https_proxy = import.meta.env.HTTPS_PROXY
+const siteToken = import.meta.env.SITE_TOKEN
 
 export const post: APIRoute = async (context) => {
+  if (siteToken) {
+    if (context.url.searchParams.get('token') !== siteToken) {
+      return new Response('Unauthorized: \n\tinput "@token=YOUR_SITE_TOKEN" to authenticate,\n\tinput "@token=clear" to clear token')
+    }
+  }
+
   const body = await context.request.json()
   const messages = body.messages
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Read the [Contributing Guide](https://github.com/ddiu8081/.github).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
-->

add optional site token to protect OpenAI API key

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

(Optional) Set the `SITE_TOKEN` in `.env` to protect your OpenAI API key from unauthorized access

  ```
  # token can be any string prarsed by regex /^@token=(.*)$/
  # except clear
  SITE_TOKEN=YOUR_SITE_TOKEN
  ```

  By adding this, vistors need to input @token=YOUR_SITE_TOKEN to access the API.

  One can also input `@token=clear` to clear the token  

### Linked Issues

none

### Additional context

Try my deploy [https://gptbot-six.vercel.app/](https://gptbot-six.vercel.app/)
<!-- e.g. is there anything you'd like reviewers to focus on? -->