### PR TITLE
fix(typography): list item marker is clipped by left border

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -26,7 +26,13 @@ export default defineConfig({
       presets: [
         presetAttributify(),
         presetUno(),
-        presetTypography(),
+        presetTypography({
+          cssExtend: {
+            "ul,ol": {
+              "padding-left": "2em"
+            }
+          }
+        }),
       ]
     }),
     solidJs()


### PR DESCRIPTION
Closes #103

<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Read the [Contributing Guide](https://github.com/ddiu8081/.github).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
-->

### Description
Reason: The @unocss/preset-typography only sets a padding-left of 1.5em for ol/ul markers that contain two characters, which is not enough space.

The simplest solution would be to increase the padding-left to 2em. To create more space for display, you can remove the container's overflow-hidden by giving the code block a wrapper container.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
#103 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->