### PR TITLE
chore: optimize dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,9 +1,11 @@
 FROM node:alpine
 RUN mkdir -p /usr/src
 WORKDIR /usr/src
+RUN npm install -g pnpm
+COPY package.json pnpm-lock.yaml /usr/src/
+RUN pnpm install
 COPY . /usr/src
-RUN npm install
-RUN npm run build
+RUN pnpm run build
 EXPOSE 3000
 ENV HOST=0.0.0.0
 ENV PORT=3000


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Read the [Contributing Guide](https://github.com/ddiu8081/.github).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
-->

### Description

Change `npm` to `pnpm` to install dependencies.

Extract the step `COPY package.json pnpm-lock.yaml /usr/src/` from the `COPY . /usr/src` in the dockerfile, and install dependencies before it. 

The optimization above utilizes Docker's image caching feature. When Docker builds an image, it tries to reuse previously built image layers to speed up the build process and reduce the time and bandwidth required for downloading. These cached layers can be considered as Docker image cache.

Before optimization, it took 140 seconds to complete the docker build command on my computer, while after optimization, it can be shortened to a minimum of 20 seconds.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->