### PR TITLE
feat: support reading configurations from environment variables in do…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Environment variables refer to the documentation below. [Docker Hub address](htt
 
 **Direct run**
 ```bash
-docker run --name=chatgpt-demo --volume=/path/.env:/usr/src/.env:rw -p 3000:3000 -d ddiu8081/chatgpt-demo:latest
+docker run --name=chatgpt-demo -e OPENAI_API_KEY=YOUR_OPEN_API_KEY -p 3000:3000 -d ddiu8081/chatgpt-demo:latest
 ```
-`/path/.env` represents the path to the local environment variable.
+`-e` define environment variables in the container.
 
 
 **Docker compose**
@@ -103,8 +103,8 @@ services:
     restart: always
     ports:
       - '3000:3000'
-    volumes:
-      - .env:/usr/src/.env
+    environment:
+      - OPENAI_API_KEY=YOUR_OPEN_API_KEY
 ```
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,9 +81,9 @@
 
 **一键运行**
 ```bash
-docker run --name=chatgpt-demo --volume=/path/.env:/usr/src/.env:rw -p 3000:3000 -d ddiu8081/chatgpt-demo:latest
+docker run --name=chatgpt-demo -e OPENAI_API_KEY=YOUR_OPEN_API_KEY -p 3000:3000 -d ddiu8081/chatgpt-demo:latest
 ```
-`/path/.env` 代表环境变量的路径。
+`-e` 在容器中定义环境变量。
 
 **使用 Docker compose**
 ```yml
@@ -96,8 +96,8 @@ services:
     restart: always
     ports:
       - '3000:3000'
-    volumes:
-      - .env:/usr/src/.env
+    environment:
+      - OPENAI_API_KEY=YOUR_OPEN_API_KEY
 ```
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,6 @@ services:
     restart: always
     ports:
         - "3000:3000"
-    volumes:
-      - .env:/usr/src/.env
+    environment:
+      - OPENAI_API_BASE_URL=YOUR_OPENAI_API_BASE_URL
+      - SITE_PASSWORD=YOUR_SITE_PASSWORD

--- a/src/pages/api/auth.ts
+++ b/src/pages/api/auth.ts
@@ -1,6 +1,7 @@
+import process from 'process'
 import type { APIRoute } from 'astro'
 
-const realPassword = import.meta.env.SITE_PASSWORD || ''
+const realPassword = import.meta.env.SITE_PASSWORD || process.env.SITE_PASSWORD || ''
 const passList = realPassword.split(',') || []
 
 export const post: APIRoute = async(context) => {

--- a/src/pages/api/generate.ts
+++ b/src/pages/api/generate.ts
@@ -1,14 +1,15 @@
 // #vercel-disable-blocks
+import * as process from 'process'
 import { ProxyAgent, fetch } from 'undici'
 // #vercel-end
 import { generatePayload, parseOpenAIStream } from '@/utils/openAI'
 import { verifySignature } from '@/utils/auth'
 import type { APIRoute } from 'astro'
 
-const apiKey = import.meta.env.OPENAI_API_KEY
-const httpsProxy = import.meta.env.HTTPS_PROXY
-const baseUrl = ((import.meta.env.OPENAI_API_BASE_URL) || 'https://api.openai.com').trim().replace(/\/$/, '')
-const sitePassword = import.meta.env.SITE_PASSWORD || ''
+const apiKey = import.meta.env.OPENAI_API_KEY || process.env.OPENAI_API_KEY
+const httpsProxy = import.meta.env.HTTPS_PROXY || process.env.HTTPS_PROXY
+const baseUrl = ((import.meta.env.OPENAI_API_BASE_URL || process.env.OPENAI_API_BASE_URL) || 'https://api.openai.com').trim().replace(/\/$/, '')
+const sitePassword = import.meta.env.SITE_PASSWORD || process.env.SITE_PASSWORD || ''
 const passList = sitePassword.split(',') || []
 
 export const post: APIRoute = async(context) => {


### PR DESCRIPTION
feat: support read configuration from system environment variable

<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Read the [Contributing Guide](https://github.com/ddiu8081/.github).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
-->

### Description

This PR addresses an issue where the application requires the .env file to exist before building the container.

To solve this problem, I've added support for reading configuration from system environment variables. This allows the application to retrieve the necessary configuration even if the .env file is not present.

Please take a look and let me know if there's anything else I can do to help. Thanks for your time and consideration!

### Linked Issues

[invalid_api_key Incorrect API key provided: undefined. #297](https://github.com/ddiu8081/chatgpt-demo/issues/297)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->