### PR TITLE
feat:add view transition animation to the theme toggle functionality

### DIFF
--- a/src/components/Themetoggle.astro
+++ b/src/components/Themetoggle.astro
@@ -77,12 +77,54 @@ const listenColorSchema = () => {
 listenColorSchema()
 toogleThemeCircle()
 
-const handleToggleClick = () => {
-  const element = document.documentElement
-  element.classList.toggle('dark')
-  const isDark = element.classList.contains('dark')
-  localStorage.setItem('theme', isDark ? 'dark' : 'light')
-  toogleThemeCircle()
+const handleToggleClick = ({ x, y }) => {
+  const root = document.documentElement
+  const isDark = root.classList.contains('dark')
+  localStorage.setItem('theme', isDark ? 'light' : 'dark')
+
+  // check if the current browser supports viewtransition API
+  const isAppearanceTransition
+    // @ts-expect-error: Transition API
+    = document.startViewTransition
+    && !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+  // if it is not supported, just toggle the class directly
+  if (!isAppearanceTransition) {
+    toogleThemeCircle()
+    root.classList.toggle('dark')
+  } else {
+    // if it is supported, use the transition API to animate the theme change
+    const endRadius = Math.hypot(
+      Math.max(x, innerWidth - x),
+      Math.max(y, innerHeight - y),
+    )
+
+    // @ts-expect-error: Transition API
+    const transition = document.startViewTransition(() => {
+      root.classList.toggle('dark')
+      toogleThemeCircle()
+    })
+    transition.ready.then(() => {
+      const clipPath = [
+      `circle(0px at ${x}px ${y}px)`,
+      `circle(${endRadius}px at ${x}px ${y}px)`,
+      ]
+      const _c = !isDark ? clipPath : [...clipPath].reverse()
+      const pseudoElement = !isDark
+        ? '::view-transition-new(root)'
+        : '::view-transition-old(root)'
+      document.documentElement.animate(
+        {
+          clipPath: _c,
+        },
+        {
+          duration: 500,
+          easing: 'ease-in',
+          pseudoElement,
+        },
+      )
+    })
+  }
 }
 themeToggle.addEventListener('click', handleToggleClick)
 </script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -71,6 +71,27 @@ const { title } = Astro.props;
   ::-webkit-scrollbar-track {
     background-color: var(--c-bg);
   }
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+    mix-blend-mode: normal;
+  }
+
+  .dark::view-transition-old(root) {
+    z-index: 1;
+  }
+
+  .dark::view-transition-new(root) {
+    z-index: 999;
+  }
+
+  ::view-transition-old(root) {
+    z-index: 999;
+  }
+
+  ::view-transition-new(root) {
+    z-index: 1;
+  }
 </style>
 
 <script>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Discuss first. It's always better to open a feature request issue first to discuss with the maintainers whether the feature is desired and the design of those features.
- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-->

### Description
Add view transition animation to the theme toggle functionality and refactor some code, the effect is shown in the figure below：

<div align=center>
<img  src="https://github.com/anse-app/chatgpt-demo/assets/58702199/6a3029ec-e7be-4207-8399-4b9ad2bc2c13"/>
</div>

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->